### PR TITLE
Make call OS independant

### DIFF
--- a/CellReset/scripts/urm_cellReset.lua
+++ b/CellReset/scripts/urm_cellReset.lua
@@ -49,7 +49,7 @@ end
 
 function cellReset.resetCell(cellDescription)
     local cell = Cell(cellDescription)
-    os.remove("mp-stuff/data/cell/" .. cell.entryFile)
+    os.remove(tes3mp.GetModDir().."/cell/" .. cell.entryFile)
 end
 
 function cellReset.manageCells()


### PR DESCRIPTION
mp-stuff is only on Windows whilst tes3mp.GetModDir() is agnostic of OS.