### PR TITLE
Disable harvested objects on cell load

### DIFF
--- a/QuickHarvesting/scripts/urm_quickHarvesting.lua
+++ b/QuickHarvesting/scripts/urm_quickHarvesting.lua
@@ -130,6 +130,7 @@ function quickHarvesting.updateCell(pid, cellDescription)
     
     for uniqueIndex,object in pairs(cell.data.objectData) do
         if quickHarvesting.plantData[uniqueIndex] ~= nil then
+            quickHarvesting.disablePlant(pid, cellDescription, uniqueIndex)
             local plantData = quickHarvesting.plantData[uniqueIndex]
             if not plantData.state then
                 if quickHarvesting.getGameTime() - plantData.harvestTime > quickHarvesting.config.respawnTime then


### PR DESCRIPTION
Previously, when a player harvested an object, logged out, and then
back in, when the cell loads harvested objects remain viewable but are
unharvestable.

Now, the disablePlant method is called when an object has harvest
data, ensuring it is disabled.